### PR TITLE
Change mocha reporter to min

### DIFF
--- a/src/browser/browser-test-runner-setup.js
+++ b/src/browser/browser-test-runner-setup.js
@@ -10,7 +10,7 @@ if (typeof callPhantom === 'function') {
   console.log = function () {
     callPhantom({ args: [].slice.call(arguments) });
   };
-  mocha.reporter('spec');
+  mocha.reporter('min');
 }
 
 mocha.ui('bdd');


### PR DESCRIPTION
Change mocha reporter from `spec` to `min` when running headless browser tests.

### Status
```
[ ] Under development
[ ] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[ ] Contains test
```
### To-do list
```
[ ] [Fix this thing]
[ ] [Fix another thing]
[ ] ...
```