### PR TITLE
Set nyc temp dir to coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules/
 dist/
 coverage/
 .idea/
-.nyc_output/
 *.log

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ The following tools are bundled into after-work.js:
 * **Chai**: an assertion library used together with a JavaScript testing framework.
 * **Sinon**: a framework for standalone test spies, stubs and mocks for JavaScript.
 * **Protractor**: a framework that utilizes Selenium for GUI tests in all major browsers.
-* **Nyc**: the Istanbul command line interface 
+* **Nyc**: the Istanbul command line interface
 * **Istanbul**: a JavaScript code coverage tool written in JavaScript.
 
 ## Test on the right "level"

--- a/src/browser/browser-test-runner.js
+++ b/src/browser/browser-test-runner.js
@@ -12,6 +12,7 @@ import disableCache from './disable-cache';
 
 const nyc = new NYC({
   reporter: ['text', 'lcov', 'text-summary'],
+  'temp-directory': './coverage/.nyc_output',
 });
 const instrumenter = nyc.instrumenter();
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -61,6 +61,7 @@ const runner = {
           '--all',
           '--include', 'src',
           '--require', 'babel-register',
+          '--temp-directory', './coverage/.nyc_output',
         );
         if (packageJSON.devDependencies['babel-plugin-istanbul']) {
           console.log('babel-plugin-istanbul installed, source-maps and instrument set to false'); // eslint-disable-line no-console


### PR DESCRIPTION
With the addition of nyc in after-work.js the temporary output from nyc created a folder in the repo root which would need to be added to the .gitignore for user. This PR sets the nyc folder for the temporary files to the coverage folder instead.

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```