### PR TITLE
Do not stub path.resolve

### DIFF
--- a/test/component/bin.spec.js
+++ b/test/component/bin.spec.js
@@ -32,7 +32,6 @@ describe('bin', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    sandbox.stub(path, 'resolve').returnsArg(1);
     sandbox.stub(path, 'relative').returnsArg(1);
     on = sandbox.stub();
     spawn = sandbox.stub(child_process, 'spawn').returns({


### PR DESCRIPTION
Stubbing path.resolve in component tests will fail when running on windows. Since the stub is not needed anyway lets remove it.

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```