### PR TITLE
Add .nycrc settings for test coverage of after-work.js

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -14,5 +14,6 @@
   ],
   "temp-directory": "./coverage/.nyc_output",
   "all": true,
-  "instrument": false
+  "instrument": false,
+  "sourceMap": false
 }

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,18 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "include": [
+    "src/"
+  ],
+  "exclude": [
+    "src/config/conf.*"
+  ],
+  "require": [
+    "babel-register"
+  ],
+  "temp-directory": "./coverage/.nyc_output",
+  "all": true,
+  "instrument": false
+}


### PR DESCRIPTION
This PR adds a .nycrc file for nyc settings when running code coverage on after-work.js instead of using default nyc settings in the runner. Also excluding conf files from coverage.

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```