### PR TITLE
feat: chai screenshot plugin

### DIFF
--- a/commands/cli/package.json
+++ b/commands/cli/package.json
@@ -38,7 +38,8 @@
     "@after-work.js/node": "^5.0.0-beta.2",
     "@after-work.js/protractor": "^5.0.0-beta.2",
     "@after-work.js/puppeteer": "^5.0.0-beta.2",
-    "@after-work.js/serve": "^5.0.0-beta.2"
+    "@after-work.js/serve": "^5.0.0-beta.2",
+    "@after-work.js/chai-plugin-screenshot": "^5.0.0-beta.2"
   },
   "files": [
     "/src"

--- a/commands/cli/src/preset-env.js
+++ b/commands/cli/src/preset-env.js
@@ -1,3 +1,4 @@
+const screenshotPlugin = require('@after-work.js/chai-plugin-screenshot');
 const sinon = require('sinon');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
@@ -11,3 +12,4 @@ global.expect = chai.expect;
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
+chai.Assertion.addMethod('matchImageOf', screenshotPlugin.matchImageOf);

--- a/commands/protractor/package.json
+++ b/commands/protractor/package.json
@@ -24,7 +24,6 @@
     "@after-work.js/register": "^5.0.0-beta.2",
     "@after-work.js/server": "^5.0.0-beta.2",
     "@after-work.js/utils": "^5.0.0-beta.2",
-    "@after-work.js/chai-plugin-screenshot": "^5.0.0-beta.2",
     "extend": "3.0.1",
     "handlebars": "4.0.11",
     "highlight.js": "9.12.0",

--- a/commands/protractor/package.json
+++ b/commands/protractor/package.json
@@ -24,6 +24,7 @@
     "@after-work.js/register": "^5.0.0-beta.2",
     "@after-work.js/server": "^5.0.0-beta.2",
     "@after-work.js/utils": "^5.0.0-beta.2",
+    "@after-work.js/chai-plugin-screenshot": "^5.0.0-beta.2",
     "extend": "3.0.1",
     "handlebars": "4.0.11",
     "highlight.js": "9.12.0",

--- a/commands/protractor/src/plugins/screenshoter/index.js
+++ b/commands/protractor/src/plugins/screenshoter/index.js
@@ -1,8 +1,5 @@
 /* global browser */
-const screenshotPlugin = require('@after-work.js/chai-plugin-screenshot');
 const utils = require('./utils');
-
-global.chai.Assertion.addMethod('matchImageOf', screenshotPlugin.matchImageOf);
 
 const screenshoter = {
   /**

--- a/commands/protractor/src/plugins/screenshoter/index.js
+++ b/commands/protractor/src/plugins/screenshoter/index.js
@@ -1,7 +1,8 @@
 /* global browser */
+const screenshotPlugin = require('@after-work.js/chai-plugin-screenshot');
 const utils = require('./utils');
 
-global.chai.Assertion.addMethod('matchImageOf', utils.matchImageOf);
+global.chai.Assertion.addMethod('matchImageOf', screenshotPlugin.matchImageOf);
 
 const screenshoter = {
   /**

--- a/commands/protractor/src/plugins/screenshoter/utils.js
+++ b/commands/protractor/src/plugins/screenshoter/utils.js
@@ -1,9 +1,6 @@
 /* globals document, Element, window */
-const path = require('path');
 const fs = require('fs');
 const jimp = require('jimp');
-const util = require('util');
-const mkdirp = require('mkdirp');
 
 function getBoundingClientRect(selector, cb) {
   /* eslint-disable */
@@ -29,13 +26,6 @@ const utils = {
   getBrowserName(browser) {
     return browser.getCapabilities();
   },
-  fileExists(filePath) {
-    return new Promise((resolve) => {
-      fs.lstat(filePath, (err) => {
-        resolve(!err);
-      });
-    });
-  },
   removeFile(filePath) {
     return new Promise((resolve, reject) => {
       fs.unlink(filePath, (err) => {
@@ -49,28 +39,6 @@ const utils = {
   },
   removeFiles(...files) {
     return Promise.all(files.map(file => this.removeFile(file)));
-  },
-  writeImage(img, filePath) {
-    return new Promise((resolve, reject) => {
-      img.write(filePath, (err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    });
-  },
-  compare(baseline, regressionImg, tolerance) {
-    return jimp.read(baseline).then((baselineImg) => {
-      const distance = jimp.distance(baselineImg, regressionImg);
-      const diff = jimp.diff(baselineImg, regressionImg);
-      return {
-        diffImg: diff.image,
-        isEqual: distance <= Math.max(0.02, tolerance) && diff.percent <= tolerance,
-        equality: `distance: ${distance}, percent: ${diff.percent}`,
-      };
-    });
   },
   takeImageOf(browser, {
     selector = 'body', offsetX = 0, offsetY = 0, offsetWidth = 0, offsetHeight = 0,
@@ -97,60 +65,6 @@ const utils = {
       artifactsPath: browser.artifactsPath,
       platform: caps.get('platform').replace(/ /g, '-').toLowerCase(),
     })));
-  },
-  matchImageOf(id, folder = '', tolerance = 0.002) {
-    const promise = this._obj.then ? this._obj : Promise.resolve(this._obj); // eslint-disable-line
-    return promise.then((meta) => {
-      const imageName = util.format('%s-%s-%s.png', id, meta.platform, meta.browserName);
-
-      mkdirp.sync(path.resolve(meta.artifactsPath, 'baseline', folder));
-      mkdirp.sync(path.resolve(meta.artifactsPath, 'regression', folder));
-      mkdirp.sync(path.resolve(meta.artifactsPath, 'diff', folder));
-
-      const baseline = path.resolve(meta.artifactsPath, 'baseline', folder, imageName);
-      const regression = path.resolve(meta.artifactsPath, 'regression', folder, imageName);
-      const diff = path.resolve(meta.artifactsPath, 'diff', folder, imageName);
-
-      // Injecting images into assert
-      const expected = {
-        baseline: path.join('baseline', folder, imageName).replace(/\\/g, '/'),
-        diff: path.join('diff', folder, imageName).replace(/\\/g, '/'),
-        regression: path.join('regression', folder, imageName).replace(/\\/g, '/'),
-      };
-
-      const actual = {};
-
-      return utils.fileExists(baseline).then((exists) => {
-        if (!exists) {
-          return utils.writeImage(meta.img, baseline).then(() => {
-            this.assert(
-              false,
-              `No baseline found! New baseline generated at ${`${meta.artifactsPath}/${expected.baseline}`}`,
-              `No baseline found! New baseline generated at ${`${meta.artifactsPath}/${expected.baseline}`}`,
-              JSON.stringify(expected),
-              actual,
-            );
-          });
-        }
-        return utils.compare(baseline, meta.img, tolerance).then((comparison) => {
-          if (comparison.isEqual) {
-            return comparison;
-          }
-          return Promise.all([
-            utils.writeImage(meta.img, regression),
-            utils.writeImage(comparison.diffImg, diff)]).then(() => {
-            this.assert(
-              comparison.isEqual === true,
-              `expected ${id} equality to be less than ${tolerance}, but was ${comparison.equality}`,
-              `expected ${id} equality to be greater than ${tolerance}, but was ${comparison.equality}`,
-              JSON.stringify(expected),
-              actual,
-            );
-            return comparison;
-          });
-        });
-      });
-    });
   },
 };
 

--- a/commands/protractor/test/unit/plugins/screenshoter/utils.spec.js
+++ b/commands/protractor/test/unit/plugins/screenshoter/utils.spec.js
@@ -1,6 +1,4 @@
-const path = require('path');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const jimp = require('jimp');
 const utils = require('../../../../src/plugins/screenshoter/utils');
 
@@ -13,18 +11,6 @@ describe('Screenshoter Utils', () => {
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  describe('fileExists', () => {
-    it('should return true if file exists', () => {
-      sandbox.stub(fs, 'lstat').callsArgWith(1, false);
-      return expect(utils.fileExists('foo')).to.eventually.equal(true);
-    });
-
-    it("should return false if file doesn't exist", () => {
-      sandbox.stub(fs, 'lstat').callsArgWith(1, true);
-      return expect(utils.fileExists('foo')).to.eventually.equal(false);
-    });
   });
 
   describe('removeFile', () => {
@@ -49,86 +35,6 @@ describe('Screenshoter Utils', () => {
       const error = new Error('error');
       sandbox.stub(utils, 'removeFile').returns(Promise.reject(error));
       return expect(utils.removeFiles('foo', 'bar', 'baz')).to.eventually.be.rejectedWith(error);
-    });
-  });
-
-  describe('writeImage', () => {
-    let img;
-
-    beforeEach(() => {
-      img = { write: sandbox.stub() };
-    });
-
-    it('should write an image to a file', () => {
-      img.write.callsArgWith(1);
-      return expect(utils.writeImage(img, 'foo')).to.eventually.be.fulfilled.and.be.an('undefined');
-    });
-
-    it("should reject if image file couldn't be created", () => {
-      img.write.callsArgWith(1, 'error');
-      return expect(utils.writeImage(img, 'foo')).to.eventually.be.rejectedWith('error');
-    });
-  });
-
-  describe('compare', () => {
-    let jimpRead;
-    let jimpDistance;
-    let jimpDiff;
-
-    beforeEach(() => {
-      jimpRead = sandbox.stub(jimp, 'read');
-      jimpDistance = sandbox.stub(jimp, 'distance');
-      jimpDiff = sandbox.stub(jimp, 'diff');
-    });
-
-    it('should be equal if the tolerance is met', () => {
-      const distance = 0;
-      const diffImg = {};
-      const percent = 0;
-      jimpRead.returns(Promise.resolve({}));
-      jimpDistance.returns(distance);
-      jimpDiff.returns({ image: diffImg, percent });
-
-      return expect(utils.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
-        diffImg,
-        isEqual: true,
-        equality: `distance: ${distance}, percent: ${percent}`,
-      });
-    });
-
-    it("should not be equal if the tolerance isn't met", () => {
-      const distance = 0.1;
-      const diffImg = {};
-      const percent = 0;
-      jimpRead.returns(Promise.resolve({}));
-      jimpDistance.returns(distance);
-      jimpDiff.returns({ image: diffImg, percent });
-
-      return expect(utils.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
-        diffImg,
-        isEqual: false,
-        equality: `distance: ${distance}, percent: ${percent}`,
-      });
-    });
-
-    it("should not be equal if the tolerance isn't met", () => {
-      const distance = 0.1;
-      const diffImg = {};
-      const percent = 0;
-      jimpRead.returns(Promise.resolve({}));
-      jimpDistance.returns(distance);
-      jimpDiff.returns({ image: diffImg, percent });
-
-      return expect(utils.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
-        diffImg,
-        isEqual: false,
-        equality: `distance: ${distance}, percent: ${percent}`,
-      });
-    });
-
-    it('should reject with error', () => {
-      jimpRead.returns(Promise.reject(new Error('error')));
-      expect(utils.compare('baseline', 'regression', 0)).to.eventually.be.rejected.and.have.property('message', 'error');
     });
   });
 
@@ -220,89 +126,5 @@ describe('Screenshoter Utils', () => {
       });
       expect(result.browserName).to.equal('chrome');
     }));
-  });
-
-  describe('matchImageOf', () => {
-    let chaiCtx;
-    let matchImageOf;
-    let fileExists;
-    let writeImage;
-    let compare;
-    let mkdir;
-    const baselinePath = 'artifacts/baseline/';
-    const baseline = `${baselinePath}id-windows-nt-chrome.png`;
-    const regressionPath = 'artifacts/regression/';
-    const regression = `${regressionPath}id-windows-nt-chrome.png`;
-    const diffPath = 'artifacts/diff/';
-    const diff = `${diffPath}id-windows-nt-chrome.png`;
-    const img = {};
-
-    beforeEach(() => {
-      sandbox.stub(path, 'resolve').callsFake((...args) => args.join('/').replace('//', '/'));
-      fileExists = sandbox.stub(utils, 'fileExists');
-      writeImage = sandbox.stub(utils, 'writeImage');
-      compare = sandbox.stub(utils, 'compare');
-      chaiCtx = {
-        _obj: Promise.resolve({
-          img, browserName: 'chrome', artifactsPath: 'artifacts', platform: 'windows-nt',
-        }),
-        assert: sinon.stub(),
-      };
-      matchImageOf = utils.matchImageOf.bind(chaiCtx);
-      sandbox.stub(process, 'cwd').returns('foo');
-      mkdir = sandbox.stub(mkdirp, 'sync');
-    });
-
-    it("should write baseline if it's not existing", () => {
-      fileExists.returns(Promise.resolve(false));
-      writeImage.returns(Promise.resolve());
-      return matchImageOf('id').then(() => {
-        expect(writeImage).to.have.been.calledWith({}, baseline);
-      });
-    });
-
-    it('should compare and resolve if considered equal to baseline', () => {
-      fileExists.returns(Promise.resolve(true));
-      writeImage.returns(Promise.resolve());
-      compare.returns(Promise.resolve({ equality: 0, isEqual: true }));
-      return matchImageOf('id').then((comparison) => {
-        expect(comparison).to.deep.equal({ equality: 0, isEqual: true });
-      });
-    });
-
-    it('should reject if not considered equal to baseline', () => {
-      const diffImg = {};
-      fileExists.returns(Promise.resolve(true));
-      writeImage.returns(Promise.resolve());
-      compare.returns(Promise.resolve({ isEqual: false, diffImg }));
-      return matchImageOf('id').then(() => {
-        expect(writeImage.callCount).to.equal(2);
-        expect(writeImage.firstCall).to.have.been.calledWithExactly(img, regression);
-        expect(writeImage.secondCall).to.have.been.calledWithExactly(diffImg, diff);
-      });
-    });
-
-    it('should create the default artifacts folders', () => {
-      fileExists.returns(Promise.resolve(false));
-      writeImage.returns(Promise.resolve());
-      return matchImageOf('id').then(() => {
-        expect(mkdir.callCount).to.equal(3);
-        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath);
-        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath);
-        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath);
-      });
-    });
-
-    it('should create the artifacts folders with subfolders', () => {
-      const folders = 'foo/bar';
-      fileExists.returns(Promise.resolve(false));
-      writeImage.returns(Promise.resolve());
-      return matchImageOf('id', folders).then(() => {
-        expect(mkdir.callCount).to.equal(3);
-        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath + folders);
-        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath + folders);
-        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath + folders);
-      });
-    });
   });
 });

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
   "packages": [
     "commands/*",
     "commands-common/*",
-    "examples/*"
+    "examples/*",
+    "plugins/*"
   ],
   "npmClient": "npm",
   "npmClientArgs": [

--- a/plugins/chai-plugin-screenshot/package.json
+++ b/plugins/chai-plugin-screenshot/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@after-work.js/chai-plugin-screenshot",
+  "version": "5.0.0-beta.2",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Chai assertion plugin for compering screenshots",
+  "main": "src/index.js",
+  "scripts": {
+    "lint": "eslint src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/qlik-oss/after-work.js.git"
+  },
+  "author": "QlikTech International AB",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/qlik-oss/after-work.js/issues"
+  },
+  "homepage": "https://github.com/qlik-oss/after-work.js#readme",
+  "dependencies": {
+    "@after-work.js/utils": "^5.0.0-beta.2",
+    "jimp": "0.2.28",
+    "mkdirp": "0.5.1"
+  },
+  "files": [
+    "/src"
+  ]
+}

--- a/plugins/chai-plugin-screenshot/package.json
+++ b/plugins/chai-plugin-screenshot/package.json
@@ -1,24 +1,13 @@
 {
   "name": "@after-work.js/chai-plugin-screenshot",
+  "private": true,
   "version": "5.0.0-beta.2",
-  "publishConfig": {
-    "access": "public"
-  },
   "description": "Chai assertion plugin for compering screenshots",
   "main": "src/index.js",
   "scripts": {
     "lint": "eslint src"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/qlik-oss/after-work.js.git"
-  },
   "author": "QlikTech International AB",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/qlik-oss/after-work.js/issues"
-  },
-  "homepage": "https://github.com/qlik-oss/after-work.js#readme",
   "dependencies": {
     "@after-work.js/utils": "^5.0.0-beta.2",
     "jimp": "0.2.28",

--- a/plugins/chai-plugin-screenshot/src/index.js
+++ b/plugins/chai-plugin-screenshot/src/index.js
@@ -33,7 +33,7 @@ const plugin = {
       return jimp.read(input);
     }
 
-    return Promise.reject(new Error(`Unable to convert to an image. Unsupported type '${type}'.`));
+    return Promise.reject(new Error(`Unable to create image. Unsupported type '${type}'.`));
   },
   fileExists(filePath) {
     return new Promise((resolve) => {
@@ -71,7 +71,9 @@ const plugin = {
   } = {}) {
     const promise = this._obj.then ? this._obj : Promise.resolve(this._obj); // eslint-disable-line
     return promise.then((meta) => {
-      const imageName = util.format(`%s-%s-%s.${type}`, id, meta.platform || platform, meta.browserName || browserName);
+      const imageName = [id, meta.platform || platform, meta.browserName || browserName]
+        .filter(s => !!s)
+        .reduceRight((prev, curr, i, ary) => `${curr}${i === ary.length - 1 ? '.' : '-'}${prev}`, `${type}`);
 
       const basePath = meta.artifactsPath || artifactsPath;
       mkdirp.sync(path.resolve(basePath, 'baseline', folder));

--- a/plugins/chai-plugin-screenshot/src/index.js
+++ b/plugins/chai-plugin-screenshot/src/index.js
@@ -60,7 +60,7 @@ const plugin = {
       equality: `distance: ${distance}, percent: ${diff.percent}`,
     });
   },
-  // TODO do not make a breaking change with second and third argument?
+  // TODO do not make a breaking change? Create a new method instead?
   matchImageOf(id, {
     type = 'png',
     platform = '',
@@ -71,7 +71,7 @@ const plugin = {
   } = {}) {
     const promise = this._obj.then ? this._obj : Promise.resolve(this._obj); // eslint-disable-line
     return promise.then((meta) => {
-      const imageName = util.format('%s-%s-%s.png', id, meta.platform || platform, meta.browserName || browserName);
+      const imageName = util.format(`%s-%s-%s.${type}`, id, meta.platform || platform, meta.browserName || browserName);
 
       const basePath = meta.artifactsPath || artifactsPath;
       mkdirp.sync(path.resolve(basePath, 'baseline', folder));

--- a/plugins/chai-plugin-screenshot/src/index.js
+++ b/plugins/chai-plugin-screenshot/src/index.js
@@ -78,9 +78,9 @@ const plugin = {
       mkdirp.sync(path.resolve(basePath, 'regression', folder));
       mkdirp.sync(path.resolve(basePath, 'diff', folder));
 
-      const baselinePath = path.resolve(basePath, 'baseline', imageName);
-      const regressionPath = path.resolve(basePath, 'regression', imageName);
-      const diffPath = path.resolve(basePath, 'diff', imageName);
+      const baselinePath = path.resolve(basePath, 'baseline', folder, imageName);
+      const regressionPath = path.resolve(basePath, 'regression', folder, imageName);
+      const diffPath = path.resolve(basePath, 'diff', folder, imageName);
 
       // Injecting images into assert
       const expected = {

--- a/plugins/chai-plugin-screenshot/src/index.js
+++ b/plugins/chai-plugin-screenshot/src/index.js
@@ -1,0 +1,139 @@
+const path = require('path');
+const fs = require('fs');
+const jimp = require('jimp');
+const util = require('util');
+const mkdirp = require('mkdirp');
+
+function toImage(input) {
+  const type = typeof input;
+  const isObj = type === 'object';
+
+  if (type === 'string') {
+    // If string assume it's a path
+    return jimp.read(input);
+  }
+
+  if (input instanceof jimp || (isObj && input.img instanceof jimp)) {
+    // Input is an instance of Jimp
+    return input.img ? Promise.resolve(input.img) : Promise.resolve(input);
+  }
+
+  if (isObj && (input.getBuffer || (input.img && input.img.getBuffer))) {
+    // Input is a Jimp object where instanceof doesn't validate to true
+    const fn = (resolve, reject) => (input.img ? input.img : input).getBuffer(
+      jimp.AUTO,
+      (e, b) => (e ? reject(e) : resolve(b)),
+    );
+    return new Promise(fn)
+      .then(buffer => jimp.read(buffer));
+  }
+
+  if (Buffer.isBuffer(input)) {
+    return jimp.read(input);
+  }
+
+  return Promise.reject(new Error(`Unable to convert to an image. Unsupported type '${type}'.`));
+}
+
+const plugin = {
+  fileExists(filePath) {
+    return new Promise((resolve) => {
+      fs.lstat(filePath, err => resolve(!err));
+    });
+  },
+  writeImage(img, filePath) {
+    return new Promise((resolve, reject) => {
+      img.write(filePath, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  },
+  compare(baselineImg, regressionImg, tolerance) {
+    const distance = jimp.distance(baselineImg, regressionImg);
+    const diff = jimp.diff(baselineImg, regressionImg);
+    return Promise.resolve({
+      diffImg: diff.image,
+      isEqual: distance <= Math.max(0.02, tolerance) && diff.percent <= tolerance,
+      equality: `distance: ${distance}, percent: ${diff.percent}`,
+    });
+  },
+  matchImageOf(id, {
+    type = 'png',
+    platform = '',
+    browserName = '',
+    folder = '',
+    tolerance = 0.002,
+  }) {
+    const promise = this._obj.then ? this._obj : Promise.resolve(this._obj); // eslint-disable-line
+    return promise.then((meta) => {
+      const imageName = util.format('%s-%s-%s.png', id, meta.platform || platform, meta.browserName || browserName);
+
+      const basePath = meta.artifactsPath || folder;
+      mkdirp.sync(path.resolve(basePath, 'baseline'));
+      mkdirp.sync(path.resolve(basePath, 'regression'));
+      mkdirp.sync(path.resolve(basePath, 'diff'));
+
+      const baselinePath = path.resolve(basePath, 'baseline', imageName);
+      const regressionPath = path.resolve(basePath, 'regression', imageName);
+      const diffPath = path.resolve(basePath, 'diff', imageName);
+
+      // Injecting images into assert
+      const expected = {
+        baseline: path.join('baseline', imageName).replace(/\\/g, '/'),
+        diff: path.join('diff', imageName).replace(/\\/g, '/'),
+        regression: path.join('regression', imageName).replace(/\\/g, '/'),
+      };
+      const actual = {};
+      const resolvedMeta = typeof meta === 'string' ? Buffer.from(meta, 'base64') : meta;
+
+      return plugin.fileExists(baselinePath).then((exists) => {
+        if (!exists) { // File doesnt exist
+          return Promise.resolve(toImage(resolvedMeta))
+            .then(regressionImg => plugin.writeImage(regressionImg, baselinePath)
+              .then(() => {
+                this.assert(
+                  false,
+                  `No baseline found! New baseline generated at ${`${basePath}/${expected.baseline}`}`,
+                  `No baseline found! New baseline generated at ${`${basePath}/${expected.baseline}`}`,
+                  JSON.stringify(expected),
+                  actual,
+                );
+              }));
+        }
+
+        return Promise.all([
+          toImage(baselinePath),
+          toImage(resolvedMeta),
+        ]).then((images) => {
+          const baselineImg = images[0];
+          const regressionImg = images[1];
+
+          return plugin.compare(baselineImg, regressionImg, tolerance).then((comparison) => {
+            if (comparison.isEqual) {
+              return comparison;
+            }
+            return Promise.all([
+              plugin.writeImage(regressionImg, regressionPath),
+              plugin.writeImage(comparison.diffImg, diffPath),
+            ]).then(() => {
+              this.assert(
+                comparison.isEqual === true,
+                `expected ${id} equality to be less than ${tolerance}, but was ${comparison.equality}`,
+                `expected ${id} equality to be greater than ${tolerance}, but was ${comparison.equality}`,
+                JSON.stringify(expected),
+                actual,
+              );
+              return comparison;
+            });
+          });
+        });
+      });
+    });
+  },
+};
+
+module.exports = plugin;

--- a/plugins/chai-plugin-screenshot/src/index.js
+++ b/plugins/chai-plugin-screenshot/src/index.js
@@ -4,38 +4,37 @@ const jimp = require('jimp');
 const util = require('util');
 const mkdirp = require('mkdirp');
 
-function toImage(input) {
-  const type = typeof input;
-  const isObj = type === 'object';
-
-  if (type === 'string') {
-    // If string assume it's a path
-    return jimp.read(input);
-  }
-
-  if (input instanceof jimp || (isObj && input.img instanceof jimp)) {
-    // Input is an instance of Jimp
-    return input.img ? Promise.resolve(input.img) : Promise.resolve(input);
-  }
-
-  if (isObj && (input.getBuffer || (input.img && input.img.getBuffer))) {
-    // Input is a Jimp object where instanceof doesn't validate to true
-    const fn = (resolve, reject) => (input.img ? input.img : input).getBuffer(
-      jimp.AUTO,
-      (e, b) => (e ? reject(e) : resolve(b)),
-    );
-    return new Promise(fn)
-      .then(buffer => jimp.read(buffer));
-  }
-
-  if (Buffer.isBuffer(input)) {
-    return jimp.read(input);
-  }
-
-  return Promise.reject(new Error(`Unable to convert to an image. Unsupported type '${type}'.`));
-}
-
 const plugin = {
+  toImage(input) {
+    const type = typeof input;
+    const isObj = type === 'object';
+
+    if (type === 'string') {
+      // If string assume it's a path
+      return jimp.read(input);
+    }
+
+    if (input instanceof jimp || (isObj && input.img instanceof jimp)) {
+      // Input is an instance of Jimp
+      return input.img ? Promise.resolve(input.img) : Promise.resolve(input);
+    }
+
+    if (isObj && (input.getBuffer || (input.img && input.img.getBuffer))) {
+      // Input is a Jimp object where instanceof doesn't validate to true
+      const fn = (resolve, reject) => (input.img ? input.img : input).getBuffer(
+        jimp.AUTO,
+        (e, b) => (e ? reject(e) : resolve(b)),
+      );
+      return new Promise(fn)
+        .then(buffer => jimp.read(buffer));
+    }
+
+    if (Buffer.isBuffer(input)) {
+      return jimp.read(input);
+    }
+
+    return Promise.reject(new Error(`Unable to convert to an image. Unsupported type '${type}'.`));
+  },
   fileExists(filePath) {
     return new Promise((resolve) => {
       fs.lstat(filePath, err => resolve(!err));
@@ -61,21 +60,23 @@ const plugin = {
       equality: `distance: ${distance}, percent: ${diff.percent}`,
     });
   },
+  // TODO do not make a breaking change with second and third argument?
   matchImageOf(id, {
     type = 'png',
     platform = '',
     browserName = '',
     folder = '',
+    artifactsPath = '',
     tolerance = 0.002,
-  }) {
+  } = {}) {
     const promise = this._obj.then ? this._obj : Promise.resolve(this._obj); // eslint-disable-line
     return promise.then((meta) => {
       const imageName = util.format('%s-%s-%s.png', id, meta.platform || platform, meta.browserName || browserName);
 
-      const basePath = meta.artifactsPath || folder;
-      mkdirp.sync(path.resolve(basePath, 'baseline'));
-      mkdirp.sync(path.resolve(basePath, 'regression'));
-      mkdirp.sync(path.resolve(basePath, 'diff'));
+      const basePath = meta.artifactsPath || artifactsPath;
+      mkdirp.sync(path.resolve(basePath, 'baseline', folder));
+      mkdirp.sync(path.resolve(basePath, 'regression', folder));
+      mkdirp.sync(path.resolve(basePath, 'diff', folder));
 
       const baselinePath = path.resolve(basePath, 'baseline', imageName);
       const regressionPath = path.resolve(basePath, 'regression', imageName);
@@ -92,7 +93,7 @@ const plugin = {
 
       return plugin.fileExists(baselinePath).then((exists) => {
         if (!exists) { // File doesnt exist
-          return Promise.resolve(toImage(resolvedMeta))
+          return Promise.resolve(plugin.toImage(resolvedMeta))
             .then(regressionImg => plugin.writeImage(regressionImg, baselinePath)
               .then(() => {
                 this.assert(
@@ -106,8 +107,8 @@ const plugin = {
         }
 
         return Promise.all([
-          toImage(baselinePath),
-          toImage(resolvedMeta),
+          plugin.toImage(baselinePath),
+          plugin.toImage(resolvedMeta),
         ]).then((images) => {
           const baselineImg = images[0];
           const regressionImg = images[1];

--- a/plugins/chai-plugin-screenshot/test/screenshot.spec.js
+++ b/plugins/chai-plugin-screenshot/test/screenshot.spec.js
@@ -110,7 +110,7 @@ describe('chai-plugin-screenshot', () => {
       compare = sandbox.stub(plugin, 'compare');
       toImage = sandbox.stub(plugin, 'toImage');
       chaiCtx = {
-        _obj: Promise.resolve({
+        _obj: Promise.resolve({ // takeImageOf context
           img, browserName: 'chrome', artifactsPath: 'artifacts', platform: 'windows-nt',
         }),
         assert: sinon.stub(),
@@ -171,6 +171,23 @@ describe('chai-plugin-screenshot', () => {
         expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath + folder);
         expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath + folder);
         expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath + folder);
+      });
+    });
+
+    it('should create the artifacts folders from options object', () => {
+      chaiCtx = {
+        _obj: Promise.resolve({}), // Change context something else than takeImageOf
+        assert: sinon.stub(),
+      };
+      matchImageOf = plugin.matchImageOf.bind(chaiCtx);
+
+      fileExists.returns(Promise.resolve(false));
+      writeImage.returns(Promise.resolve());
+      return matchImageOf('id', { artifactsPath: 'testing', folder: 'test' }).then(() => {
+        expect(mkdir.callCount).to.equal(3);
+        expect(mkdir.firstCall).to.have.been.calledWithExactly('testing/baseline/test');
+        expect(mkdir.secondCall).to.have.been.calledWithExactly('testing/regression/test');
+        expect(mkdir.thirdCall).to.have.been.calledWithExactly('testing/diff/test');
       });
     });
   });

--- a/plugins/chai-plugin-screenshot/test/screenshot.spec.js
+++ b/plugins/chai-plugin-screenshot/test/screenshot.spec.js
@@ -1,0 +1,193 @@
+const path = require('path');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const jimp = require('jimp');
+const plugin = require('../src');
+
+describe('chai-plugin-screenshot', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('fileExists', () => {
+    it('should return true if file exists', () => {
+      sandbox.stub(fs, 'lstat').callsArgWith(1, false);
+      return expect(plugin.fileExists('foo')).to.eventually.equal(true);
+    });
+
+    it("should return false if file doesn't exist", () => {
+      sandbox.stub(fs, 'lstat').callsArgWith(1, true);
+      return expect(plugin.fileExists('foo')).to.eventually.equal(false);
+    });
+  });
+
+  describe('writeImage', () => {
+    let img;
+
+    beforeEach(() => {
+      img = { write: sandbox.stub() };
+    });
+
+    it('should write an image to a file', () => {
+      img.write.callsArgWith(1);
+      return expect(plugin.writeImage(img, 'foo')).to.eventually.be.fulfilled.and.be.an('undefined');
+    });
+
+    it("should reject if image file couldn't be created", () => {
+      img.write.callsArgWith(1, 'error');
+      return expect(plugin.writeImage(img, 'foo')).to.eventually.be.rejectedWith('error');
+    });
+  });
+
+  describe('compare', () => {
+    let jimpRead;
+    let jimpDistance;
+    let jimpDiff;
+
+    beforeEach(() => {
+      jimpRead = sandbox.stub(jimp, 'read');
+      jimpDistance = sandbox.stub(jimp, 'distance');
+      jimpDiff = sandbox.stub(jimp, 'diff');
+    });
+
+    it('should be equal if the tolerance is met', () => {
+      const distance = 0;
+      const diffImg = {};
+      const percent = 0;
+      jimpRead.returns(Promise.resolve({}));
+      jimpDistance.returns(distance);
+      jimpDiff.returns({ image: diffImg, percent });
+
+      return expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
+        diffImg,
+        isEqual: true,
+        equality: `distance: ${distance}, percent: ${percent}`,
+      });
+    });
+
+    it("should not be equal if the tolerance isn't met", () => {
+      const distance = 0.1;
+      const diffImg = {};
+      const percent = 0;
+      jimpRead.returns(Promise.resolve({}));
+      jimpDistance.returns(distance);
+      jimpDiff.returns({ image: diffImg, percent });
+
+      return expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
+        diffImg,
+        isEqual: false,
+        equality: `distance: ${distance}, percent: ${percent}`,
+      });
+    });
+
+    it("should not be equal if the tolerance isn't met", () => {
+      const distance = 0.1;
+      const diffImg = {};
+      const percent = 0;
+      jimpRead.returns(Promise.resolve({}));
+      jimpDistance.returns(distance);
+      jimpDiff.returns({ image: diffImg, percent });
+
+      return expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
+        diffImg,
+        isEqual: false,
+        equality: `distance: ${distance}, percent: ${percent}`,
+      });
+    });
+
+    it('should reject with error', () => {
+      jimpRead.returns(Promise.reject(new Error('error')));
+      expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.rejected.and.have.property('message', 'error');
+    });
+  });
+
+  describe('matchImageOf', () => {
+    let chaiCtx;
+    let matchImageOf;
+    let fileExists;
+    let writeImage;
+    let compare;
+    let mkdir;
+    const baselinePath = 'artifacts/baseline/';
+    const baseline = `${baselinePath}id-windows-nt-chrome.png`;
+    const regressionPath = 'artifacts/regression/';
+    const regression = `${regressionPath}id-windows-nt-chrome.png`;
+    const diffPath = 'artifacts/diff/';
+    const diff = `${diffPath}id-windows-nt-chrome.png`;
+    const img = {};
+
+    beforeEach(() => {
+      sandbox.stub(path, 'resolve').callsFake((...args) => args.join('/').replace('//', '/'));
+      fileExists = sandbox.stub(plugin, 'fileExists');
+      writeImage = sandbox.stub(plugin, 'writeImage');
+      compare = sandbox.stub(plugin, 'compare');
+      chaiCtx = {
+        _obj: Promise.resolve({
+          img, browserName: 'chrome', artifactsPath: 'artifacts', platform: 'windows-nt',
+        }),
+        assert: sinon.stub(),
+      };
+      matchImageOf = plugin.matchImageOf.bind(chaiCtx);
+      sandbox.stub(process, 'cwd').returns('foo');
+      mkdir = sandbox.stub(mkdirp, 'sync');
+    });
+
+    it("should write baseline if it's not existing", () => {
+      fileExists.returns(Promise.resolve(false));
+      writeImage.returns(Promise.resolve());
+      return matchImageOf('id').then(() => {
+        expect(writeImage).to.have.been.calledWith({}, baseline);
+      });
+    });
+
+    it('should compare and resolve if considered equal to baseline', () => {
+      fileExists.returns(Promise.resolve(true));
+      writeImage.returns(Promise.resolve());
+      compare.returns(Promise.resolve({ equality: 0, isEqual: true }));
+      return matchImageOf('id').then((comparison) => {
+        expect(comparison).to.deep.equal({ equality: 0, isEqual: true });
+      });
+    });
+
+    it('should reject if not considered equal to baseline', () => {
+      const diffImg = {};
+      fileExists.returns(Promise.resolve(true));
+      writeImage.returns(Promise.resolve());
+      compare.returns(Promise.resolve({ isEqual: false, diffImg }));
+      return matchImageOf('id').then(() => {
+        expect(writeImage.callCount).to.equal(2);
+        expect(writeImage.firstCall).to.have.been.calledWithExactly(img, regression);
+        expect(writeImage.secondCall).to.have.been.calledWithExactly(diffImg, diff);
+      });
+    });
+
+    it('should create the default artifacts folders', () => {
+      fileExists.returns(Promise.resolve(false));
+      writeImage.returns(Promise.resolve());
+      return matchImageOf('id').then(() => {
+        expect(mkdir.callCount).to.equal(3);
+        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath);
+        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath);
+        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath);
+      });
+    });
+
+    it('should create the artifacts folders with subfolders', () => {
+      const folders = 'foo/bar';
+      fileExists.returns(Promise.resolve(false));
+      writeImage.returns(Promise.resolve());
+      return matchImageOf('id', folders).then(() => {
+        expect(mkdir.callCount).to.equal(3);
+        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath + folders);
+        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath + folders);
+        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath + folders);
+      });
+    });
+  });
+});

--- a/plugins/chai-plugin-screenshot/test/screenshot.spec.js
+++ b/plugins/chai-plugin-screenshot/test/screenshot.spec.js
@@ -85,26 +85,6 @@ describe('chai-plugin-screenshot', () => {
         equality: `distance: ${distance}, percent: ${percent}`,
       });
     });
-
-    it("should not be equal if the tolerance isn't met", () => {
-      const distance = 0.1;
-      const diffImg = {};
-      const percent = 0;
-      jimpRead.returns(Promise.resolve({}));
-      jimpDistance.returns(distance);
-      jimpDiff.returns({ image: diffImg, percent });
-
-      return expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.fulfilled.and.deep.equal({
-        diffImg,
-        isEqual: false,
-        equality: `distance: ${distance}, percent: ${percent}`,
-      });
-    });
-
-    it('should reject with error', () => {
-      jimpRead.returns(Promise.reject(new Error('error')));
-      expect(plugin.compare('baseline', 'regression', 0)).to.eventually.be.rejected.and.have.property('message', 'error');
-    });
   });
 
   describe('matchImageOf', () => {
@@ -113,6 +93,7 @@ describe('chai-plugin-screenshot', () => {
     let fileExists;
     let writeImage;
     let compare;
+    let toImage;
     let mkdir;
     const baselinePath = 'artifacts/baseline/';
     const baseline = `${baselinePath}id-windows-nt-chrome.png`;
@@ -127,6 +108,7 @@ describe('chai-plugin-screenshot', () => {
       fileExists = sandbox.stub(plugin, 'fileExists');
       writeImage = sandbox.stub(plugin, 'writeImage');
       compare = sandbox.stub(plugin, 'compare');
+      toImage = sandbox.stub(plugin, 'toImage');
       chaiCtx = {
         _obj: Promise.resolve({
           img, browserName: 'chrome', artifactsPath: 'artifacts', platform: 'windows-nt',
@@ -136,6 +118,8 @@ describe('chai-plugin-screenshot', () => {
       matchImageOf = plugin.matchImageOf.bind(chaiCtx);
       sandbox.stub(process, 'cwd').returns('foo');
       mkdir = sandbox.stub(mkdirp, 'sync');
+
+      toImage.returns(Promise.resolve(img));
     });
 
     it("should write baseline if it's not existing", () => {
@@ -179,14 +163,14 @@ describe('chai-plugin-screenshot', () => {
     });
 
     it('should create the artifacts folders with subfolders', () => {
-      const folders = 'foo/bar';
+      const folder = 'foo/bar';
       fileExists.returns(Promise.resolve(false));
       writeImage.returns(Promise.resolve());
-      return matchImageOf('id', folders).then(() => {
+      return matchImageOf('id', { folder }).then(() => {
         expect(mkdir.callCount).to.equal(3);
-        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath + folders);
-        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath + folders);
-        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath + folders);
+        expect(mkdir.firstCall).to.have.been.calledWithExactly(baselinePath + folder);
+        expect(mkdir.secondCall).to.have.been.calledWithExactly(regressionPath + folder);
+        expect(mkdir.thirdCall).to.have.been.calledWithExactly(diffPath + folder);
       });
     });
   });


### PR DESCRIPTION
This PR makes the chai assertion`matchImageOf` available for all test runners.

- The assert plugin and all the dependent methods are moved from the protractor command to a separate plugins folder.
- The tight integration with `takeImageOf` should work as before. But is on a TODO to remove at some point.
- 

### Status
```
[ ] Under development
[ ] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[ ] Contains test
```
### To-do list
```
[ ] Currently only applicable when using preset-env
[ ] Remove the dependency to the takeImageOf method in the protractor runner
[ ] Make the plugin a public package
[ ] Find a better way to configure the artifacts directory (currently via a method param)
```