### PR TITLE
fix: honor babel 7 ignore

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,9 @@ module.exports = (api) => {
             modules: 'amd',
           }],
         ],
+        ignore: [
+          '**/ignore.js',
+        ],
       };
     default:
       return {

--- a/examples/chrome-js/src/a.js
+++ b/examples/chrome-js/src/a.js
@@ -1,1 +1,3 @@
+import './ignore';
+
 export default () => 'a';

--- a/examples/chrome-js/src/ignore.js
+++ b/examples/chrome-js/src/ignore.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+(function() {
+})();

--- a/packages/transform/src/index.js
+++ b/packages/transform/src/index.js
@@ -68,6 +68,9 @@ function transformFile(filename, argv, content = null) {
   babelOpts.ast = false;
   const { babel } = argv.babel;
   const transform = babel.transform(content, babelOpts);
+  if (!transform) {
+    return content;
+  }
   fileCache.setSync(filename, transform, argv);
   return transform.code;
 }


### PR DESCRIPTION
Babel 7 will return null for ignored files
Ensure returning the file content
