### PR TITLE
Keep cache for local versions of sinon and chai

### DIFF
--- a/packages/register/src/index.js
+++ b/packages/register/src/index.js
@@ -137,7 +137,9 @@ class AW {
     const [filename] = utils.getCurrentFilenameStackInfo(this.testFiles);
     const deps = utils.getAllDependencies(this.srcFiles, filename);
     deps.forEach(d => utils.safeDeleteCache(d));
-    Object.keys(require.cache).filter(f => f !== filename && this.testFiles.indexOf(f) === -1).forEach(f => utils.safeDeleteCache(f));
+
+    const isTestLibFile = f => f.indexOf('node_modules') > -1 && (f.indexOf('sinon') > -1 || f.indexOf('chai') > -1);
+    Object.keys(require.cache).filter(f => f !== filename && this.testFiles.indexOf(f) === -1 && !isTestLibFile(f)).forEach(f => utils.safeDeleteCache(f));
 
     const mods = reqs.map((r) => {
       const p = require.resolve(path.resolve(path.dirname(filename), r));


### PR DESCRIPTION
There is a problem when using local versions of `sinon` and `chai` (and not the global ones provided by AW). The file caches for these versions are deleted when using mocks, which results in external setup like `chai.use(sinonChai)` is lost.