### PR TITLE
fix: reduce risk of falsy test case match

### DIFF
--- a/plugins/chai-plugin-snapshot/src/index.js
+++ b/plugins/chai-plugin-snapshot/src/index.js
@@ -26,7 +26,7 @@ module.exports = function snapshot(runner) {
     let currentTestName = null;
     for (let i = lineno - 1; i >= 0; i -= 1) {
       const line = lines[i];
-      if (line.trimLeft().startsWith('it')) {
+      if (line.trimLeft().startsWith('it(')) {
         [, currentTestName] = line.match(/it.*\((.*),/);
         break;
       }


### PR DESCRIPTION
The traversal of matching for a `currentTestName` in https://github.com/qlik-oss/after-work.js/blob/master/plugins/chai-plugin-snapshot/src/index.js#L29 assumes any row starting with `it` contains the test name, the following would throw an error since it matches the `it` in  `items` and would try to extract the test name from `ems`:

```js
it('should do magic', () => {
  const props = {
    items: []
  };
  expect('').toMatchSnapshot();
});
```

The changes in this PR reduces the risk of that by including `(` when checking the start of the line.

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[ ] Contains test
```