### PR TITLE
fix(protractor): fallback to platformName if platform is missing

### DIFF
--- a/commands/protractor/src/plugins/screenshoter/utils.js
+++ b/commands/protractor/src/plugins/screenshoter/utils.js
@@ -50,16 +50,16 @@ const utils = {
           };
         }));
       })
-      .then(meta => this.getBrowserName(browser).then(caps => ({
-        img: meta.img,
-        rect: meta.rect,
-        browserName: caps.get('browserName').replace(' ', '-'),
-        artifactsPath: browser.reporterInfo.artifactsPath,
-        platform: caps
-          .get('platform')
-          .replace(/ /g, '-')
-          .toLowerCase(),
-      })));
+      .then(meta => this.getBrowserName(browser).then((caps) => {
+        const platform = caps.get('platform') || caps.get('platformName') || 'unknown';
+        return {
+          img: meta.img,
+          rect: meta.rect,
+          browserName: caps.get('browserName').replace(' ', '-'),
+          artifactsPath: browser.reporterInfo.artifactsPath,
+          platform: platform.replace(/ /g, '-').toLowerCase(),
+        };
+      }));
   },
 };
 

--- a/commands/protractor/test/unit/plugins/screenshoter/utils.spec.js
+++ b/commands/protractor/test/unit/plugins/screenshoter/utils.spec.js
@@ -162,5 +162,21 @@ describe('Screenshoter Utils', () => {
         });
         expect(result.browserName).to.equal('chrome');
       }));
+
+    it('should work with IE11 capabilities', async () => {
+      Capabilities.delete('platform');
+      Capabilities.set('platform', 'windows');
+      Capabilities.set('browserName', 'internet explorer');
+      const result = await utils.takeImageOf(browser, {});
+
+      expect(result.rect).to.deep.equal({
+        top: 100,
+        left: 200,
+        width: 200,
+        height: 100,
+      });
+      expect(result.browserName).to.equal('internet-explorer');
+      expect(result.platform).to.equal('windows');
+    });
   });
 });


### PR DESCRIPTION
fix crash when running takeImageOf in IE11

### Status

- [x] Waiting for code review
- [ ] Waiting for merge

### Information

- [x] Contains test

