### PR TITLE
fix: add safety checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "url": "ssh://git@github.com:qlik-oss/after-work.js.git"
   },
   "devDependencies": {
-    "@after-work.js/cli": "6.0.5",
     "@after-work.js/cdp": "6.0.5",
+    "@after-work.js/cli": "6.0.5",
     "@after-work.js/node": "6.0.5",
-    "@after-work.js/puppeteer": "6.0.5",
     "@after-work.js/protractor": "6.0.5",
+    "@after-work.js/puppeteer": "6.0.5",
     "@after-work.js/serve": "6.0.5",
     "@babel/core": "7.4.0",
     "@babel/plugin-transform-react-jsx": "7.3.0",
@@ -43,10 +43,11 @@
     "protractor": "5.4.2",
     "requirejs": "2.3.6",
     "typescript": "3.3.4000",
-    "yargs": "13.2.2",
+    "webdriver-manager": "^12.1.6",
     "webpack": "4.29.6",
     "webpack-cli": "3.3.0",
-    "webpack-dev-server": "3.2.1"
+    "webpack-dev-server": "3.2.1",
+    "yargs": "13.2.2"
   },
   "workspaces": [
     "commands/*",

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -160,6 +160,18 @@ const addDefaults = (argv) => {
   ];
 };
 
+const safeGetModule = (name) => {
+  let found = importCwd.silent(name);
+  if (!found) {
+    try {
+      found = require(name);
+    } catch (err) {
+      found = null;
+    }
+  }
+  return found;
+};
+
 const utils = {
   addDefaults,
   getPackages,
@@ -220,24 +232,13 @@ const utils = {
       `${prefix} ${msg.length > 60 ? '...' : ''}${msg.slice(-59)}`,
     );
   },
-  safeGetModule(name) {
-    let found = importCwd.silent(name);
-    if (!found) {
-      try {
-        found = require(name);
-      } catch (err) {
-        found = null;
-      }
-    }
-    return found;
-  },
   coerceBabel(opt) {
     if (opt.enable && opt.core && typeof opt.core === 'string') {
       opt.babel = importCwd(opt.core);
     } else if (opt.enable && !opt.core) {
-      let core = utils.safeGetModule('@babel/core');
+      let core = safeGetModule('@babel/core');
       if (!core) {
-        core = utils.safeGetModule('babel-core');
+        core = safeGetModule('babel-core');
         if (!core) {
           throw new Error('Can not get babel core module');
         }
@@ -245,13 +246,13 @@ const utils = {
       opt.babel = core;
     }
     if (opt.enable && typeof opt.babelPluginIstanbul === 'string') {
-      const babelPluginIstanbul = utils.safeGetModule(opt.babelPluginIstanbul);
+      const babelPluginIstanbul = safeGetModule(opt.babelPluginIstanbul);
       opt.babelPluginIstanbul = babelPluginIstanbul
         ? babelPluginIstanbul.default
         : null;
     }
     if (opt.enable && typeof opt.typescript === 'string') {
-      opt.typescript = utils.safeGetModule(opt.typescript);
+      opt.typescript = safeGetModule(opt.typescript);
     }
     return opt;
   },

--- a/plugins/preset-plugin/package.json
+++ b/plugins/preset-plugin/package.json
@@ -27,6 +27,7 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "chai-subset": "1.6.0",
+    "import-cwd": "3.0.0",
     "sinon": "6.3.5",
     "sinon-chai": "3.3.0"
   },

--- a/plugins/preset-plugin/src/index.js
+++ b/plugins/preset-plugin/src/index.js
@@ -1,4 +1,16 @@
-const { safeGetModule } = require('@after-work.js/utils');
+const importCwd = require('import-cwd');
+
+const safeGetModule = (name) => {
+  let found = importCwd.silent(name);
+  if (!found) {
+    try {
+      found = require(name);
+    } catch (err) {
+      found = null;
+    }
+  }
+  return found;
+};
 
 module.exports = (runner) => {
   const sinon = safeGetModule('sinon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10219,6 +10219,23 @@ webdriver-manager@^12.0.6:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webdriver-manager@^12.1.6:
+  version "12.1.6"
+  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.1.6.tgz#9e5410c506d1a7e0a7aa6af91ba3d5bb37f362b6"
+  integrity sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==
+  dependencies:
+    adm-zip "^0.4.9"
+    chalk "^1.1.1"
+    del "^2.2.0"
+    glob "^7.0.3"
+    ini "^1.3.4"
+    minimist "^1.2.0"
+    q "^1.4.1"
+    request "^2.87.0"
+    rimraf "^2.5.2"
+    semver "^5.3.0"
+    xml2js "^0.4.17"
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
The `safeGetModule` wasn't safe in the meaning it didn't handle the correct caller path. This is moved more locally to ensure finding a module.