### PR TITLE
fix: pass `extension` to nyc

### DIFF
--- a/commands/node/src/index.js
+++ b/commands/node/src/index.js
@@ -145,9 +145,7 @@ class Runner extends EventEmitter {
       snapshotState.save();
       if (uncheckedCount && !this.argv.updateSnapshot) {
         console.error(
-          `\u001b[33mObsolete snapshot:\u001b[0m \u001b[31m${currentTestName}\u001b[0m \u001b[33m\n\u001b[90mat (${
-            snapshotState._snapshotPath
-          })\u001b[0m`,
+          `\u001b[33mObsolete snapshot:\u001b[0m \u001b[31m${currentTestName}\u001b[0m \u001b[33m\n\u001b[90mat (${snapshotState._snapshotPath})\u001b[0m`,
         );
       }
     });

--- a/commands/node/src/options.js
+++ b/commands/node/src/options.js
@@ -2,6 +2,7 @@ const {
   TEST_GLOB,
   SRC_GLOB,
   WATCH_GLOB,
+  DEFAULT_EXT,
   DEFAULT_SRC_EXT_PATTERN,
   DEFAULT_TEST_EXT_PATTERN,
   DEFAULT_INSTRUMENT_EXCLUDE_PATTERN,
@@ -159,6 +160,11 @@ module.exports = {
   'nyc.require': {
     description: 'Require path',
     default: [],
+    type: 'array',
+  },
+  'nyc.extension': {
+    description: 'Include extensions',
+    default: DEFAULT_EXT,
     type: 'array',
   },
   'nyc.include': {

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -19,10 +19,12 @@ const lernaPackages = ((lerna && lerna.packages) || [])
   .reduce(reducePkgs, []);
 const packagesPath = [...workspaces, ...lernaPackages];
 
-const DEFAULT_TEST_EXT_PATTERN = '*.{spec,test}.{js,jsx,ts,tsx}';
+const DEFAULT_EXT = ['js', 'ts', 'jsx', 'tsx'];
+
+const DEFAULT_TEST_EXT_PATTERN = `*.{spec,test}.{${DEFAULT_EXT.join(',')}}`;
 const DEFAULT_TEST_GLOB_PATTERN = `**/${DEFAULT_TEST_EXT_PATTERN}`;
 
-const DEFAULT_SRC_EXT_PATTERN = '*.{js,ts,jsx,tsx}';
+const DEFAULT_SRC_EXT_PATTERN = `*.{${DEFAULT_EXT.join(',')}}`;
 const DEFAULT_SRC_GLOB_PATTERN = `**/${DEFAULT_SRC_EXT_PATTERN}`;
 const DEFAULT_SRC_EXCLUDE_PATTERN = [
   '**/coverage/**',
@@ -186,6 +188,7 @@ const utils = {
   TEST_GLOB,
   SRC_GLOB,
   WATCH_GLOB,
+  DEFAULT_EXT,
   DEFAULT_TEST_EXT_PATTERN,
   DEFAULT_TEST_GLOB_PATTERN,
   DEFAULT_SRC_EXT_PATTERN,


### PR DESCRIPTION
Ensure passing `DEFAULT_EXT` so we get coverage on for example `jsx`