### PR TITLE
chore: add typings for `aw.mock` function

### DIFF
--- a/packages/register/src/index.d.ts
+++ b/packages/register/src/index.d.ts
@@ -1,0 +1,27 @@
+declare const aw: {
+  /**
+   *
+   * @param mocks - define mocks by key value pair where key supports glob pattern and value either a function that returns the mocked module or a string.
+   * @param reqs - modules to be required.
+   * @example
+   * ```javascript
+   * // Only call this in file scope or in a `Mocha` `before` hook to get correct coverage results.
+   * // Mock components
+   * //
+   * const [{ default: A, }] = aw.mock([
+   *   [
+   *     require.resolve('../src/b'), () => <span>b</span>,
+   *     require.resolve('../src/c'), () => <div>c</div>,
+   *   ]
+   *  ], ['../src/a']);
+   * //
+   * // Mock all css files to an empty string
+   * //
+   * aw.mock([['*.css', () => '']], ['../src/my-module']);
+   * ```
+   */
+  mock(
+    mocks: [string, string | (() => any)][],
+    reqs: string[],
+  ): NodeModule[];
+};

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -62,7 +62,7 @@ const getPackages = ({ testExt, srcExt }) => {
   return packagesMap;
 };
 
-const excludeGlob = ['!**/node_modules/**', '!./node_modules/**'];
+const excludeGlob = ['!**/node_modules/**', '!./node_modules/**', '!**/*.d.ts', '!./*.d.ts'];
 
 const getTestGlob = argv => {
   const { testExt, scope } = argv;


### PR DESCRIPTION
This add rudimentary typings for the global `aw.mock` with examples

![image](https://user-images.githubusercontent.com/682243/76192776-e888bd00-61e2-11ea-9da5-d4dc021c9b00.png)
