### PR TITLE
docs: add deprecation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 `after-work.js` is an unified test framework highly configurable through cli and configuration files allowing tests to be executed in the desired context.
 
+# Deprecated
+
+`after-work.js` is deprecated. Here are some alternatives:
+
+- Jest: <https://jestjs.io/>
+- Mocha: <https://mochajs.org/>
+- Ava: <https://github.com/avajs/ava>
+- Testing-library: <https://testing-library.com/>
+- Playwright: <https://playwright.dev/>
+- Puppeteer: <https://pptr.dev/>
+- Cypress: <https://www.cypress.io/>
+
 ## Requirements
 
 ### Default runner


### PR DESCRIPTION
`after-work.js` has served its purpose and it is time to sunset it.

- No ownership
- Additional burden
- Very out of date

Will run `npm deprecate` after merging.